### PR TITLE
Added Integer.MAX_VALUE as default timeout instead of 20000 milisecon…

### DIFF
--- a/android/MpOS API/src/br/ufc/mdcc/mpos/net/core/ClientTcp.java
+++ b/android/MpOS API/src/br/ufc/mdcc/mpos/net/core/ClientTcp.java
@@ -47,7 +47,7 @@ public final class ClientTcp extends ClientAbstract {
 	@Override
 	public void connect(String ip, int port) throws IOException, MissedEventException {
 		socket = new Socket(ip, port);
-		socket.setSoTimeout(20000);
+		socket.setSoTimeout(Integer.MAX_VALUE);
 
 		if (threadControl) {
 			if (event == null) {


### PR DESCRIPTION
…ds. It is important to avoid socket TCP timeout exceptions when the offload operation demand too much time.
